### PR TITLE
pulling in dev changes so maybe python 3.4 won't fail CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -666,7 +666,6 @@ omit =
     homeassistant/components/weather/darksky.py
     homeassistant/components/weather/metoffice.py
     homeassistant/components/weather/openweathermap.py
-    homeassistant/components/weather/yweather.py
     homeassistant/components/weather/zamg.py
     homeassistant/components/zeroconf.py
     homeassistant/components/zwave/util.py

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['concord232==0.14']
+REQUIREMENTS = ['concord232==0.15']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,4 +121,4 @@ class Concord232Alarm(alarm.AlarmControlPanel):
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
-        self._alarm.arm('auto')
+        self._alarm.arm('away')

--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -13,6 +13,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.util import dt as dt_util
+from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
 
 REQUIREMENTS = ['alarmdecoder==1.13.2']
 
@@ -68,7 +69,8 @@ DEVICE_USB_SCHEMA = vol.Schema({
 
 ZONE_SCHEMA = vol.Schema({
     vol.Required(CONF_ZONE_NAME): cv.string,
-    vol.Optional(CONF_ZONE_TYPE, default=DEFAULT_ZONE_TYPE): cv.string,
+    vol.Optional(CONF_ZONE_TYPE,
+                 default=DEFAULT_ZONE_TYPE): vol.Any(DEVICE_CLASSES_SCHEMA),
     vol.Optional(CONF_ZONE_RFID): cv.string})
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -55,7 +55,7 @@ def async_trigger(hass, config, action):
 
         # Ignore changes to state attributes if from/to is in use
         if (not match_all and from_s is not None and to_s is not None and
-                from_s.last_changed == to_s.last_changed):
+                from_s.state == to_s.state):
             return
 
         if not time_delta:

--- a/homeassistant/components/binary_sensor/concord232.py
+++ b/homeassistant/components/binary_sensor/concord232.py
@@ -15,7 +15,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import (CONF_HOST, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['concord232==0.14']
+REQUIREMENTS = ['concord232==0.15']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -99,6 +99,11 @@ class RestBinarySensor(BinarySensorDevice):
         return self._device_class
 
     @property
+    def available(self):
+        """Return the availability of this sensor."""
+        return self.rest.data is not None
+
+    @property
     def is_on(self):
         """Return true if the binary sensor is on."""
         if self.rest.data is None:

--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -82,6 +82,7 @@ class UnifiVideoCamera(Camera):
         self.is_streaming = False
         self._connect_addr = None
         self._camera = None
+        self._motion_status = False
 
     @property
     def name(self):
@@ -93,6 +94,12 @@ class UnifiVideoCamera(Camera):
         """Return true if the camera is recording."""
         caminfo = self._nvr.get_camera(self._uuid)
         return caminfo['recordingSettings']['fullTimeRecordEnabled']
+
+    @property
+    def motion_detection_enabled(self):
+        """Camera Motion Detection Status."""
+        caminfo = self._nvr.get_camera(self._uuid)
+        return caminfo['recordingSettings']['motionRecordEnabled']
 
     @property
     def brand(self):
@@ -165,3 +172,26 @@ class UnifiVideoCamera(Camera):
                     raise
 
         return _get_image()
+
+    def set_motion_detection(self, mode):
+        """Set motion detection on or off."""
+        from uvcclient.nvr import NvrError
+        if mode is True:
+            set_mode = 'motion'
+        else:
+            set_mode = 'none'
+
+        try:
+            self._nvr.set_recordmode(self._uuid, set_mode)
+            self._motion_status = mode
+        except NvrError as err:
+            _LOGGER.error("Unable to set recordmode to " + set_mode)
+            _LOGGER.debug(err)
+
+    def enable_motion_detection(self):
+        """Enable motion detection in camera."""
+        self.set_motion_detection(True)
+
+    def disable_motion_detection(self):
+        """Disable motion detection in camera."""
+        self.set_motion_detection(False)

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY, ClimateDevice, DOMAIN, PLATFORM_SCHEMA,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
     SUPPORT_FAN_MODE, SUPPORT_SWING_MODE,
-    SUPPORT_AUX_HEAT, SUPPORT_ON_OFF)
+    SUPPORT_ON_OFF)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -54,7 +54,7 @@ FIELD_TO_FLAG = {
     'mode': SUPPORT_OPERATION_MODE,
     'swing': SUPPORT_SWING_MODE,
     'targetTemperature': SUPPORT_TARGET_TEMPERATURE,
-    'on': SUPPORT_AUX_HEAT | SUPPORT_ON_OFF,
+    'on': SUPPORT_ON_OFF,
 }
 
 
@@ -232,11 +232,9 @@ class SensiboClimate(ClimateDevice):
         return self._name
 
     @property
-    def is_aux_heat_on(self):
+    def is_on(self):
         """Return true if AC is on."""
         return self._ac_states['on']
-
-    is_on = is_aux_heat_on
 
     @property
     def min_temp(self):
@@ -296,21 +294,18 @@ class SensiboClimate(ClimateDevice):
                 self._id, 'swing', swing_mode, self._ac_states)
 
     @asyncio.coroutine
-    def async_turn_aux_heat_on(self):
+    def async_on(self):
         """Turn Sensibo unit on."""
         with async_timeout.timeout(TIMEOUT):
             yield from self._client.async_set_ac_state_property(
                 self._id, 'on', True, self._ac_states)
 
     @asyncio.coroutine
-    def async_turn_aux_heat_off(self):
+    def async_off(self):
         """Turn Sensibo unit on."""
         with async_timeout.timeout(TIMEOUT):
             yield from self._client.async_set_ac_state_property(
                 self._id, 'on', False, self._ac_states)
-
-    async_on = async_turn_aux_heat_on
-    async_off = async_turn_aux_heat_off
 
     @asyncio.coroutine
     def async_assume_state(self, state):

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/climate.tado/
 """
 import logging
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import (PRECISION_TENTHS, TEMP_CELSIUS)
 from homeassistant.components.climate import (
     ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
 from homeassistant.const import ATTR_TEMPERATURE
@@ -191,6 +191,11 @@ class TadoClimate(ClimateDevice):
     def is_away_mode_on(self):
         """Return true if away mode is on."""
         return self._is_away
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return PRECISION_TENTHS
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/cover/rfxtrx.py
+++ b/homeassistant/components/cover/rfxtrx.py
@@ -4,12 +4,29 @@ Support for RFXtrx cover components.
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/cover.rfxtrx/
 """
+import voluptuous as vol
+
 import homeassistant.components.rfxtrx as rfxtrx
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import CoverDevice, PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.components.rfxtrx import (
+    CONF_AUTOMATIC_ADD, CONF_FIRE_EVENT, DEFAULT_SIGNAL_REPETITIONS,
+    CONF_SIGNAL_REPETITIONS, CONF_DEVICES)
+from homeassistant.helpers import config_validation as cv
 
 DEPENDENCIES = ['rfxtrx']
 
-PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {
+        cv.string: vol.Schema({
+            vol.Required(CONF_NAME): cv.string,
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean
+        })
+    },
+    vol.Optional(CONF_AUTOMATIC_ADD, default=False):  cv.boolean,
+    vol.Optional(CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS):
+        vol.Coerce(int),
+})
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -15,6 +15,11 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
+TAHOMA_STOP_COMMAND = {
+    'io:RollerShutterWithLowSpeedManagementIOComponent': 'my',
+    'io:RollerShutterVeluxIOComponent': 'my',
+}
+
 SCAN_INTERVAL = timedelta(seconds=60)
 
 
@@ -73,7 +78,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self.apply_action('stopIdentify')
+        self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type,
+                                                  'stopIdentify'))
 
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -15,11 +15,6 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
-TAHOMA_STOP_COMMAND = {
-    'io:RollerShutterWithLowSpeedManagementIOComponent': 'my',
-    'io:RollerShutterVeluxIOComponent': 'my',
-}
-
 SCAN_INTERVAL = timedelta(seconds=60)
 
 
@@ -78,8 +73,11 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type,
-                                                  'stopIdentify'))
+        if self.tahoma_device.type == \
+           'io:RollerShutterWithLowSpeedManagementIOComponent':
+            self.apply_action('setPosition', 'secured')
+        else:
+            self.apply_action('stopIdentify')
 
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -80,6 +80,8 @@ ATTR_VENDOR = 'vendor'
 
 SOURCE_TYPE_GPS = 'gps'
 SOURCE_TYPE_ROUTER = 'router'
+SOURCE_TYPE_BLUETOOTH = 'bluetooth'
+SOURCE_TYPE_BLUETOOTH_LE = 'bluetooth_le'
 
 NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(None, vol.Schema({
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,

--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.components.device_tracker import (
     YAML_DEVICES, CONF_TRACK_NEW, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-    PLATFORM_SCHEMA, load_config
+    PLATFORM_SCHEMA, load_config, SOURCE_TYPE_BLUETOOTH_LE
 )
 import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
@@ -54,7 +54,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 new_devices[address] = 1
                 return
 
-        see(mac=BLE_PREFIX + address, host_name=name.strip("\x00"))
+        see(mac=BLE_PREFIX + address, host_name=name.strip("\x00"),
+            source_type=SOURCE_TYPE_BLUETOOTH_LE)
 
     def discover_ble_devices():
         """Discover Bluetooth LE devices."""

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.components.device_tracker import (
     YAML_DEVICES, CONF_TRACK_NEW, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-    load_config, PLATFORM_SCHEMA, DEFAULT_TRACK_NEW)
+    load_config, PLATFORM_SCHEMA, DEFAULT_TRACK_NEW, SOURCE_TYPE_BLUETOOTH)
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,7 +33,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     def see_device(device):
         """Mark a device as seen."""
-        see(mac=BT_PREFIX + device[0], host_name=device[1])
+        see(mac=BT_PREFIX + device[0], host_name=device[1],
+            source_type=SOURCE_TYPE_BLUETOOTH)
 
     def discover_devices():
         """Discover Bluetooth devices."""

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20180110.0', 'user-agents==1.1.0']
+REQUIREMENTS = ['home-assistant-frontend==20180112.0', 'user-agents==1.1.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log']

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -54,12 +54,12 @@ MAPPING_COMPONENT = {
         }
     ],
     cover.DOMAIN: [
-        TYPE_LIGHT, TRAIT_ONOFF, {
+        TYPE_SWITCH, TRAIT_ONOFF, {
             cover.SUPPORT_SET_POSITION: TRAIT_BRIGHTNESS
         }
     ],
     media_player.DOMAIN: [
-        TYPE_LIGHT, TRAIT_ONOFF, {
+        TYPE_SWITCH, TRAIT_ONOFF, {
             media_player.SUPPORT_VOLUME_SET: TRAIT_BRIGHTNESS
         }
     ],

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -304,7 +304,20 @@ class HistoryPeriodView(HomeAssistantView):
             elapsed = time.perf_counter() - timer_start
             _LOGGER.debug(
                 'Extracted %d states in %fs', sum(map(len, result)), elapsed)
-        return self.json(result)
+
+        # Reorder the result to respect the ordering given by any
+        # entities explicitly included in the configuration.
+
+        sorted_result = []
+        for order_entity in self.filters.included_entities:
+            for state_list in result:
+                if state_list[0].entity_id == order_entity:
+                    sorted_result.append(state_list)
+                    result.remove(state_list)
+                    break
+        sorted_result.extend(result)
+
+        return self.json(sorted_result)
 
 
 class Filters(object):

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['pyhomematic==0.1.36']
+REQUIREMENTS = ['pyhomematic==0.1.37']
 DOMAIN = 'homematic'
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ HM_DEVICE_TYPES = {
         'MotionIP', 'RemoteMotion', 'WeatherSensor', 'TiltSensor',
         'IPShutterContact', 'HMWIOSwitch', 'MaxShutterContact', 'Rain',
         'WiredSensor', 'PresenceIP'],
-    DISCOVER_COVER: ['Blind', 'KeyBlind']
+    DISCOVER_COVER: ['Blind', 'KeyBlind', 'IPKeyBlind', 'IPKeyBlindTilt']
 }
 
 HM_IGNORE_DISCOVERY_NODE = [

--- a/homeassistant/components/light/rfxtrx.py
+++ b/homeassistant/components/light/rfxtrx.py
@@ -6,15 +6,32 @@ https://home-assistant.io/components/light.rfxtrx/
 """
 import logging
 
+import voluptuous as vol
+
 import homeassistant.components.rfxtrx as rfxtrx
-from homeassistant.components.light import (ATTR_BRIGHTNESS,
-                                            SUPPORT_BRIGHTNESS, Light)
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+from homeassistant.components.rfxtrx import (
+    CONF_AUTOMATIC_ADD, CONF_FIRE_EVENT, DEFAULT_SIGNAL_REPETITIONS,
+    CONF_SIGNAL_REPETITIONS, CONF_DEVICES)
+from homeassistant.helpers import config_validation as cv
 
 DEPENDENCIES = ['rfxtrx']
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {
+        cv.string: vol.Schema({
+            vol.Required(CONF_NAME): cv.string,
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean
+        })
+    },
+    vol.Optional(CONF_AUTOMATIC_ADD, default=False):  cv.boolean,
+    vol.Optional(CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS):
+        vol.Coerce(int),
+})
 
 SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -2,7 +2,7 @@
 Support for Xiaomi Philips Lights (LED Ball & Ceiling Lamp, Eyecare Lamp 2).
 
 For more details about this platform, please refer to the documentation
-https://home-assistant.io/components/light.xiaomi_philipslight/
+https://home-assistant.io/components/light.xiaomi_miio/
 """
 import asyncio
 from functools import partial

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -17,6 +17,11 @@ DEPENDENCIES = ['zha']
 
 DEFAULT_DURATION = 0.5
 
+CAPABILITIES_COLOR_XY = 0x08
+CAPABILITIES_COLOR_TEMP = 0x10
+
+UNSUPPORTED_ATTRIBUTE = 0x86
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
@@ -32,7 +37,34 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     except (AttributeError, KeyError):
         pass
 
+    if discovery_info.get('color_capabilities') is None:
+        # ZCL Version 4 devices don't support the color_capabilities attribute.
+        # In this version XY support is mandatory, but we need to probe to
+        # determine if the device supports color temperature.
+        discovery_info['color_capabilities'] = CAPABILITIES_COLOR_XY
+        result = yield from safe_read(
+            endpoint.light_color, ['color_temperature'])
+        if result.get('color_temperature') is not UNSUPPORTED_ATTRIBUTE:
+            discovery_info['color_capabilities'] |= CAPABILITIES_COLOR_TEMP
+
     async_add_devices([Light(**discovery_info)], update_before_add=True)
+
+
+@asyncio.coroutine
+def safe_read(cluster, attributes):
+    """Swallow all exceptions from network read.
+
+    If we throw during initialization, setup fails. Rather have an
+    entity that exists, but is in a maybe wrong state, than no entity.
+    """
+    try:
+        result, _ = yield from cluster.read_attributes(
+            attributes,
+            allow_cache=False,
+        )
+        return result
+    except Exception:  # pylint: disable=broad-except
+        return {}
 
 
 class Light(zha.Entity, light.Light):
@@ -54,11 +86,11 @@ class Light(zha.Entity, light.Light):
             self._supported_features |= light.SUPPORT_TRANSITION
             self._brightness = 0
         if zcl_clusters.lighting.Color.cluster_id in self._in_clusters:
-            color_capabilities = kwargs.get('color_capabilities', 0x10)
-            if color_capabilities & 0x10:
+            color_capabilities = kwargs['color_capabilities']
+            if color_capabilities & CAPABILITIES_COLOR_TEMP:
                 self._supported_features |= light.SUPPORT_COLOR_TEMP
 
-            if color_capabilities & 0x08:
+            if color_capabilities & CAPABILITIES_COLOR_XY:
                 self._supported_features |= light.SUPPORT_XY_COLOR
                 self._supported_features |= light.SUPPORT_RGB_COLOR
                 self._xy_color = (1.0, 1.0)
@@ -142,24 +174,6 @@ class Light(zha.Entity, light.Light):
     @asyncio.coroutine
     def async_update(self):
         """Retrieve latest state."""
-        _LOGGER.debug("%s async_update", self.entity_id)
-
-        @asyncio.coroutine
-        def safe_read(cluster, attributes):
-            """Swallow all exceptions from network read.
-
-            If we throw during initialization, setup fails. Rather have an
-            entity that exists, but is in a maybe wrong state, than no entity.
-            """
-            try:
-                result, _ = yield from cluster.read_attributes(
-                    attributes,
-                    allow_cache=False,
-                )
-                return result
-            except Exception:  # pylint: disable=broad-except
-                return {}
-
         result = yield from safe_read(self._endpoint.on_off, ['on_off'])
         self._state = result.get('on_off', self._state)
 

--- a/homeassistant/components/media_extractor.py
+++ b/homeassistant/components/media_extractor.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA)
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['youtube_dl==2017.12.28']
+REQUIREMENTS = ['youtube_dl==2017.12.31']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -186,7 +186,7 @@ class CastDevice(MediaPlayerDevice):
 
         images = self.media_status.images
 
-        return images[0].url if images else None
+        return images[0].url if images and images[0].url else None
 
     @property
     def media_title(self):

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -8,13 +8,11 @@ import logging
 import asyncio
 import urllib.parse
 import json
-import os
 import aiohttp
 import async_timeout
 
 import voluptuous as vol
 
-from homeassistant.config import load_yaml_config_file
 from homeassistant.components.media_player import (
     ATTR_MEDIA_ENQUEUE, SUPPORT_PLAY_MEDIA,
     MEDIA_TYPE_MUSIC, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, PLATFORM_SCHEMA,
@@ -126,15 +124,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)
 
-    descriptions = yield from hass.async_add_job(
-        load_yaml_config_file, os.path.join(
-            os.path.dirname(__file__), 'services.yaml'))
-
     for service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[service]['schema']
         hass.services.async_register(
             DOMAIN, service, async_service_handler,
-            description=descriptions.get(service), schema=schema)
+            schema=schema)
 
     return True
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -16,11 +16,11 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
     ATTR_ENTITY_ID, TEMP_CELSIUS,
-    CONF_DEVICE_CLASS, CONF_COMMAND_ON, CONF_COMMAND_OFF
+    CONF_DEVICES
 )
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyRFXtrx==0.20.1']
+REQUIREMENTS = ['pyRFXtrx==0.21.1']
 
 DOMAIN = 'rfxtrx'
 
@@ -31,13 +31,19 @@ ATTR_DEVICE = 'device'
 ATTR_DEBUG = 'debug'
 ATTR_STATE = 'state'
 ATTR_NAME = 'name'
-ATTR_FIREEVENT = 'fire_event'
+ATTR_FIRE_EVENT = 'fire_event'
 ATTR_DATA_TYPE = 'data_type'
 ATTR_DATA_BITS = 'data_bits'
 ATTR_DUMMY = 'dummy'
 ATTR_OFF_DELAY = 'off_delay'
+CONF_AUTOMATIC_ADD = 'automatic_add'
+CONF_DATA_TYPE = 'data_type'
 CONF_SIGNAL_REPETITIONS = 'signal_repetitions'
-CONF_DEVICES = 'devices'
+CONF_FIRE_EVENT = 'fire_event'
+CONF_DATA_BITS = 'data_bits'
+CONF_DUMMY = 'dummy'
+CONF_DEVICE = 'device'
+CONF_DEBUG = 'debug'
 EVENT_BUTTON_PRESSED = 'button_pressed'
 
 DATA_TYPES = OrderedDict([
@@ -57,93 +63,13 @@ DATA_TYPES = OrderedDict([
 RECEIVED_EVT_SUBSCRIBERS = []
 RFX_DEVICES = {}
 _LOGGER = logging.getLogger(__name__)
-RFXOBJECT = 'rfxobject'
-
-
-def _valid_device(value, device_type):
-    """Validate a dictionary of devices definitions."""
-    config = OrderedDict()
-    for key, device in value.items():
-
-        # Still accept old configuration
-        if 'packetid' in device.keys():
-            msg = 'You are using an outdated configuration of the rfxtrx ' +\
-                  'device, {}.'.format(key) +\
-                  ' Your new config should be:\n    {}: \n        name: {}'\
-                  .format(device.get('packetid'),
-                          device.get(ATTR_NAME, 'deivce_name'))
-            _LOGGER.warning(msg)
-            key = device.get('packetid')
-            device.pop('packetid')
-
-        key = str(key)
-        if not len(key) % 2 == 0:
-            key = '0' + key
-
-        if device_type == 'sensor':
-            config[key] = DEVICE_SCHEMA_SENSOR(device)
-        elif device_type == 'binary_sensor':
-            config[key] = DEVICE_SCHEMA_BINARYSENSOR(device)
-        elif device_type == 'light_switch':
-            config[key] = DEVICE_SCHEMA(device)
-        else:
-            raise vol.Invalid('Rfxtrx device is invalid')
-
-        if not config[key][ATTR_NAME]:
-            config[key][ATTR_NAME] = key
-    return config
-
-
-def valid_sensor(value):
-    """Validate sensor configuration."""
-    return _valid_device(value, "sensor")
-
-
-def valid_binary_sensor(value):
-    """Validate binary sensor configuration."""
-    return _valid_device(value, "binary_sensor")
-
-
-def _valid_light_switch(value):
-    return _valid_device(value, "light_switch")
-
-
-DEVICE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_NAME): cv.string,
-    vol.Optional(ATTR_FIREEVENT, default=False): cv.boolean,
-})
-
-DEVICE_SCHEMA_SENSOR = vol.Schema({
-    vol.Optional(ATTR_NAME, default=None): cv.string,
-    vol.Optional(ATTR_FIREEVENT, default=False): cv.boolean,
-    vol.Optional(ATTR_DATA_TYPE, default=[]):
-        vol.All(cv.ensure_list, [vol.In(DATA_TYPES.keys())]),
-})
-
-DEVICE_SCHEMA_BINARYSENSOR = vol.Schema({
-    vol.Optional(ATTR_NAME, default=None): cv.string,
-    vol.Optional(CONF_DEVICE_CLASS, default=None): cv.string,
-    vol.Optional(ATTR_FIREEVENT, default=False): cv.boolean,
-    vol.Optional(ATTR_OFF_DELAY, default=None):
-        vol.Any(cv.time_period, cv.positive_timedelta),
-    vol.Optional(ATTR_DATA_BITS, default=None): cv.positive_int,
-    vol.Optional(CONF_COMMAND_ON, default=None): cv.byte,
-    vol.Optional(CONF_COMMAND_OFF, default=None): cv.byte
-})
-
-DEFAULT_SCHEMA = vol.Schema({
-    vol.Required("platform"): DOMAIN,
-    vol.Optional(CONF_DEVICES, default={}): vol.All(dict, _valid_light_switch),
-    vol.Optional(ATTR_AUTOMATIC_ADD, default=False):  cv.boolean,
-    vol.Optional(CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS):
-        vol.Coerce(int),
-})
+DATA_RFXOBJECT = 'rfxobject'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(ATTR_DEVICE): cv.string,
-        vol.Optional(ATTR_DEBUG, default=False): cv.boolean,
-        vol.Optional(ATTR_DUMMY, default=False): cv.boolean,
+        vol.Required(CONF_DEVICE): cv.string,
+        vol.Optional(CONF_DEBUG, default=False): cv.boolean,
+        vol.Optional(CONF_DUMMY, default=False): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -152,7 +78,7 @@ def setup(hass, config):
     """Set up the RFXtrx component."""
     # Declare the Handle event
     def handle_receive(event):
-        """Handle revieved messgaes from RFXtrx gateway."""
+        """Handle revieved messages from RFXtrx gateway."""
         # Log RFXCOM event
         if not event.device.id_string:
             return
@@ -175,21 +101,22 @@ def setup(hass, config):
     dummy_connection = config[DOMAIN][ATTR_DUMMY]
 
     if dummy_connection:
-        hass.data[RFXOBJECT] =\
-            rfxtrxmod.Connect(device, None, debug=debug,
-                              transport_protocol=rfxtrxmod.DummyTransport2)
+        rfx_object = rfxtrxmod.Connect(
+            device, None, debug=debug,
+            transport_protocol=rfxtrxmod.DummyTransport2)
     else:
-        hass.data[RFXOBJECT] = rfxtrxmod.Connect(device, None, debug=debug)
+        rfx_object = rfxtrxmod.Connect(device, None, debug=debug)
 
     def _start_rfxtrx(event):
-        hass.data[RFXOBJECT].event_callback = handle_receive
+        rfx_object.event_callback = handle_receive
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, _start_rfxtrx)
 
     def _shutdown_rfxtrx(event):
         """Close connection with RFXtrx."""
-        hass.data[RFXOBJECT].close_connection()
+        rfx_object.close_connection()
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
 
+    hass.data[DATA_RFXOBJECT] = rfx_object
     return True
 
 
@@ -248,9 +175,9 @@ def get_pt2262_device(device_id):
         if (hasattr(device, 'is_lighting4') and
                 device.masked_id == get_pt2262_deviceid(device_id,
                                                         device.data_bits)):
-            _LOGGER.info("rfxtrx: found matching device %s for %s",
-                         device_id,
-                         device.masked_id)
+            _LOGGER.debug("rfxtrx: found matching device %s for %s",
+                          device_id,
+                          device.masked_id)
             return device
     return None
 
@@ -295,11 +222,11 @@ def get_devices_from_config(config, device):
         device_id = slugify(event.device.id_string.lower())
         if device_id in RFX_DEVICES:
             continue
-        _LOGGER.info("Add %s rfxtrx", entity_info[ATTR_NAME])
+        _LOGGER.debug("Add %s rfxtrx", entity_info[ATTR_NAME])
 
         # Check if i must fire event
-        fire_event = entity_info[ATTR_FIREEVENT]
-        datas = {ATTR_STATE: False, ATTR_FIREEVENT: fire_event}
+        fire_event = entity_info[ATTR_FIRE_EVENT]
+        datas = {ATTR_STATE: False, ATTR_FIRE_EVENT: fire_event}
 
         new_device = device(entity_info[ATTR_NAME], event, datas,
                             signal_repetitions)
@@ -318,14 +245,14 @@ def get_new_device(event, config, device):
         return
 
     pkt_id = "".join("{0:02x}".format(x) for x in event.data)
-    _LOGGER.info(
+    _LOGGER.debug(
         "Automatic add %s rfxtrx device (Class: %s Sub: %s Packet_id: %s)",
         device_id,
         event.device.__class__.__name__,
         event.device.subtype,
         pkt_id
     )
-    datas = {ATTR_STATE: False, ATTR_FIREEVENT: False}
+    datas = {ATTR_STATE: False, ATTR_FIRE_EVENT: False}
     signal_repetitions = config[CONF_SIGNAL_REPETITIONS]
     new_device = device(pkt_id, event, datas,
                         signal_repetitions)
@@ -370,7 +297,7 @@ def apply_received_command(event):
                 ATTR_STATE: event.values['Command'].lower()
             }
         )
-        _LOGGER.info(
+        _LOGGER.debug(
             "Rfxtrx fired event: (event_type: %s, %s: %s, %s: %s)",
             EVENT_BUTTON_PRESSED,
             ATTR_ENTITY_ID,
@@ -392,7 +319,7 @@ class RfxtrxDevice(Entity):
         self._name = name
         self._event = event
         self._state = datas[ATTR_STATE]
-        self._should_fire_event = datas[ATTR_FIREEVENT]
+        self._should_fire_event = datas[ATTR_FIRE_EVENT]
         self._brightness = 0
         self.added_to_hass = False
 
@@ -440,40 +367,35 @@ class RfxtrxDevice(Entity):
     def _send_command(self, command, brightness=0):
         if not self._event:
             return
+        rfx_object = self.hass.data[DATA_RFXOBJECT]
 
         if command == "turn_on":
             for _ in range(self.signal_repetitions):
-                self._event.device.send_on(self.hass.data[RFXOBJECT]
-                                           .transport)
+                self._event.device.send_on(rfx_object.transport)
             self._state = True
 
         elif command == "dim":
             for _ in range(self.signal_repetitions):
-                self._event.device.send_dim(self.hass.data[RFXOBJECT]
-                                            .transport, brightness)
+                self._event.device.send_dim(rfx_object.transport, brightness)
             self._state = True
 
         elif command == 'turn_off':
             for _ in range(self.signal_repetitions):
-                self._event.device.send_off(self.hass.data[RFXOBJECT]
-                                            .transport)
+                self._event.device.send_off(rfx_object.transport)
             self._state = False
             self._brightness = 0
 
         elif command == "roll_up":
             for _ in range(self.signal_repetitions):
-                self._event.device.send_open(self.hass.data[RFXOBJECT]
-                                             .transport)
+                self._event.device.send_open(rfx_object.transport)
 
         elif command == "roll_down":
             for _ in range(self.signal_repetitions):
-                self._event.device.send_close(self.hass.data[RFXOBJECT]
-                                              .transport)
+                self._event.device.send_close(rfx_object.transport)
 
         elif command == "stop_roll":
             for _ in range(self.signal_repetitions):
-                self._event.device.send_stop(self.hass.data[RFXOBJECT]
-                                             .transport)
+                self._event.device.send_stop(rfx_object.transport)
 
         if self.added_to_hass:
             self.schedule_update_ha_state()

--- a/homeassistant/components/sensor/tado.py
+++ b/homeassistant/components/sensor/tado.py
@@ -18,8 +18,10 @@ ATTR_DEVICE = 'device'
 ATTR_NAME = 'name'
 ATTR_ZONE = 'zone'
 
-SENSOR_TYPES = ['temperature', 'humidity', 'power',
-                'link', 'heating', 'tado mode', 'overlay']
+CLIMATE_SENSOR_TYPES = ['temperature', 'humidity', 'power',
+                        'link', 'heating', 'tado mode', 'overlay']
+
+HOT_WATER_SENSOR_TYPES = ['power', 'link', 'tado mode', 'overlay']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -35,10 +37,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensor_items = []
     for zone in zones:
         if zone['type'] == 'HEATING':
-            for variable in SENSOR_TYPES:
+            for variable in CLIMATE_SENSOR_TYPES:
                 sensor_items.append(create_zone_sensor(
                     tado, zone, zone['name'], zone['id'],
                     variable))
+        elif zone['type'] == 'HOT_WATER':
+            for variable in HOT_WATER_SENSOR_TYPES:
+                sensor_items.append(create_zone_sensor(
+                    tado, zone, zone['name'], zone['id'],
+                    variable
+                ))
 
     me_data = tado.get_me()
     sensor_items.append(create_device_sensor(

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -364,6 +364,38 @@ abode:
         description: Entity id of the quick action to trigger.
         example: 'binary_sensor.home_quick_action'
 
+snips:
+  say:
+    description: Send a TTS message to Snips.
+    fields:
+      text:
+        description: Text to say.
+        example: My name is snips
+      site_id:
+        description: Site to use to start session, defaults to default (optional)
+        example: bedroom
+      custom_data:
+        description: custom data that will be included with all messages in this session
+        example: user=UserName
+  say_action:
+    description: Send a TTS message to Snips to listen for a response.
+    fields:
+      text:
+        description: Text to say
+        example: My name is snips
+      site_id:
+        description: Site to use to start session, defaults to default (optional)
+        example: bedroom
+      custom_data:
+        description: custom data that will be included with all messages in this session
+        example: user=UserName
+      can_be_enqueued:
+        description: If True, session waits for an open session to end, if False session is dropped if one is running
+        example: True
+      intent_filter:
+        description: Optional Array of Strings - A list of intents names to restrict the NLU resolution to on the first query.
+        example: turnOnLights, turnOffLights
+
 input_boolean:
   toggle:
     description: Toggles an input boolean.

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -8,16 +8,28 @@ import asyncio
 import json
 import logging
 from datetime import timedelta
+
 import voluptuous as vol
+
 from homeassistant.helpers import intent, config_validation as cv
 import homeassistant.components.mqtt as mqtt
 
 DOMAIN = 'snips'
 DEPENDENCIES = ['mqtt']
+
 CONF_INTENTS = 'intents'
 CONF_ACTION = 'action'
 
+SERVICE_SAY = 'say'
+SERVICE_SAY_ACTION = 'say_action'
+
 INTENT_TOPIC = 'hermes/intent/#'
+
+ATTR_TEXT = 'text'
+ATTR_SITE_ID = 'site_id'
+ATTR_CUSTOM_DATA = 'custom_data'
+ATTR_CAN_BE_ENQUEUED = 'can_be_enqueued'
+ATTR_INTENT_FILTER = 'intent_filter'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +51,20 @@ INTENT_SCHEMA = vol.Schema({
         }
     }]
 }, extra=vol.ALLOW_EXTRA)
+
+SERVICE_SCHEMA_SAY = vol.Schema({
+    vol.Required(ATTR_TEXT): str,
+    vol.Optional(ATTR_SITE_ID, default='default'): str,
+    vol.Optional(ATTR_CUSTOM_DATA, default=''): str
+})
+
+SERVICE_SCHEMA_SAY_ACTION = vol.Schema({
+    vol.Required(ATTR_TEXT): str,
+    vol.Optional(ATTR_SITE_ID, default='default'): str,
+    vol.Optional(ATTR_CUSTOM_DATA, default=''): str,
+    vol.Optional(ATTR_CAN_BE_ENQUEUED, default=True): cv.boolean,
+    vol.Optional(ATTR_INTENT_FILTER): vol.All(cv.ensure_list),
+})
 
 
 @asyncio.coroutine
@@ -92,6 +118,39 @@ def async_setup(hass, config):
 
     yield from hass.components.mqtt.async_subscribe(
         INTENT_TOPIC, message_received)
+
+    @asyncio.coroutine
+    def snips_say(call):
+        """Send a Snips notification message."""
+        notification = {'siteId': call.data.get(ATTR_SITE_ID, 'default'),
+                        'customData': call.data.get(ATTR_CUSTOM_DATA, ''),
+                        'init': {'type': 'notification',
+                                 'text': call.data.get(ATTR_TEXT)}}
+        mqtt.async_publish(hass, 'hermes/dialogueManager/startSession',
+                           json.dumps(notification))
+        return
+
+    @asyncio.coroutine
+    def snips_say_action(call):
+        """Send a Snips action message."""
+        notification = {'siteId': call.data.get(ATTR_SITE_ID, 'default'),
+                        'customData': call.data.get(ATTR_CUSTOM_DATA, ''),
+                        'init': {'type': 'action',
+                                 'text': call.data.get(ATTR_TEXT),
+                                 'canBeEnqueued': call.data.get(
+                                     ATTR_CAN_BE_ENQUEUED, True),
+                                 'intentFilter':
+                                     call.data.get(ATTR_INTENT_FILTER, [])}}
+        mqtt.async_publish(hass, 'hermes/dialogueManager/startSession',
+                           json.dumps(notification))
+        return
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SAY, snips_say,
+        schema=SERVICE_SCHEMA_SAY)
+    hass.services.async_register(
+        DOMAIN, SERVICE_SAY_ACTION, snips_say_action,
+        schema=SERVICE_SCHEMA_SAY_ACTION)
 
     return True
 

--- a/homeassistant/components/switch/rfxtrx.py
+++ b/homeassistant/components/switch/rfxtrx.py
@@ -6,14 +6,31 @@ https://home-assistant.io/components/switch.rfxtrx/
 """
 import logging
 
+import voluptuous as vol
+
 import homeassistant.components.rfxtrx as rfxtrx
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.components.rfxtrx import (
+    CONF_AUTOMATIC_ADD, CONF_FIRE_EVENT, DEFAULT_SIGNAL_REPETITIONS,
+    CONF_SIGNAL_REPETITIONS, CONF_DEVICES)
+from homeassistant.helpers import config_validation as cv
 
 DEPENDENCIES = ['rfxtrx']
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {
+        cv.string: vol.Schema({
+            vol.Required(CONF_NAME): cv.string,
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean
+        })
+    },
+    vol.Optional(CONF_AUTOMATIC_ADD, default=False):  cv.boolean,
+    vol.Optional(CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS):
+        vol.Coerce(int),
+})
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -48,18 +48,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by a generic RF device via GPIO."""
     import rpi_rf
+    from threading import RLock
 
     gpio = config.get(CONF_GPIO)
     rfdevice = rpi_rf.RFDevice(gpio)
+    rfdevice_lock = RLock()
     switches = config.get(CONF_SWITCHES)
 
     devices = []
     for dev_name, properties in switches.items():
         devices.append(
             RPiRFSwitch(
-                hass,
                 properties.get(CONF_NAME, dev_name),
                 rfdevice,
+                rfdevice_lock,
                 properties.get(CONF_PROTOCOL),
                 properties.get(CONF_PULSELENGTH),
                 properties.get(CONF_SIGNAL_REPETITIONS),
@@ -79,13 +81,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiRFSwitch(SwitchDevice):
     """Representation of a GPIO RF switch."""
 
-    def __init__(self, hass, name, rfdevice, protocol, pulselength,
+    def __init__(self, name, rfdevice, lock, protocol, pulselength,
                  signal_repetitions, code_on, code_off):
         """Initialize the switch."""
-        self._hass = hass
         self._name = name
         self._state = False
         self._rfdevice = rfdevice
+        self._lock = lock
         self._protocol = protocol
         self._pulselength = pulselength
         self._code_on = code_on
@@ -109,9 +111,10 @@ class RPiRFSwitch(SwitchDevice):
 
     def _send_code(self, code_list, protocol, pulselength):
         """Send the code(s) with a specified pulselength."""
-        _LOGGER.info("Sending code(s): %s", code_list)
-        for code in code_list:
-            self._rfdevice.tx_code(code, protocol, pulselength)
+        with self._lock:
+            _LOGGER.info("Sending code(s): %s", code_list)
+            for code in code_list:
+                self._rfdevice.tx_code(code, protocol, pulselength)
         return True
 
     def turn_on(self):

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -40,6 +40,7 @@ TAHOMA_TYPES = {
     'rts:RollerShutterRTSComponent': 'cover',
     'rts:CurtainRTSComponent': 'cover',
     'io:RollerShutterWithLowSpeedManagementIOComponent': 'cover',
+    'io:RollerShutterVeluxIOComponent': 'cover',
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
 }

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -97,9 +97,15 @@ def async_setup(hass, config):
 
         newest, releasenotes = result
 
+        # Skip on dev
         if newest is None or 'dev' in current_version:
             return
 
+        # Load data from supervisor on hass.io
+        if hass.components.hassio.is_hassio():
+            newest = hass.components.hassio.get_homeassistant_version()
+
+        # Validate version
         if StrictVersion(newest) > StrictVersion(current_version):
             _LOGGER.info("The latest available version is %s", newest)
             hass.states.async_set(
@@ -131,6 +137,7 @@ def get_system_info(hass, include_components):
         'timezone': dt_util.DEFAULT_TIME_ZONE.zone,
         'version': current_version,
         'virtualenv': os.environ.get('VIRTUAL_ENV') is not None,
+        'hassio': hass.components.hassio.is_hassio(),
     }
 
     if include_components:

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -125,27 +125,28 @@ class YahooWeatherWeather(WeatherEntity):
     @property
     def pressure(self):
         """Return the pressure."""
-        return self._data.yahoo.Atmosphere['pressure']
+        return round(float(self._data.yahoo.Atmosphere['pressure'])/33.8637526,
+                     2)
 
     @property
     def humidity(self):
         """Return the humidity."""
-        return self._data.yahoo.Atmosphere['humidity']
+        return int(self._data.yahoo.Atmosphere['humidity'])
 
     @property
     def visibility(self):
         """Return the visibility."""
-        return self._data.yahoo.Atmosphere['visibility']
+        return round(float(self._data.yahoo.Atmosphere['visibility'])/1.61, 2)
 
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        return self._data.yahoo.Wind['speed']
+        return round(float(self._data.yahoo.Wind['speed'])/1.61, 2)
 
     @property
     def wind_bearing(self):
         """Return the wind direction."""
-        return self._data.yahoo.Wind['direction']
+        return int(self._data.yahoo.Wind['direction'])
 
     @property
     def attribution(self):

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -9,7 +9,7 @@ from homeassistant.components.discovery import SERVICE_XIAOMI_GW
 from homeassistant.const import (ATTR_BATTERY_LEVEL, EVENT_HOMEASSISTANT_STOP,
                                  CONF_MAC, CONF_HOST, CONF_PORT)
 
-REQUIREMENTS = ['PyXiaomiGateway==0.6.0']
+REQUIREMENTS = ['PyXiaomiGateway==0.7.0']
 
 ATTR_GW_MAC = 'gw_mac'
 ATTR_RINGTONE_ID = 'ringtone_id'
@@ -105,8 +105,8 @@ def setup(hass, config):
 
     discovery.listen(hass, SERVICE_XIAOMI_GW, xiaomi_gw_discovered)
 
-    from PyXiaomiGateway import PyXiaomiGateway
-    xiaomi = hass.data[PY_XIAOMI_GATEWAY] = PyXiaomiGateway(
+    from xiaomi_gateway import XiaomiGatewayDiscovery
+    xiaomi = hass.data[PY_XIAOMI_GATEWAY] = XiaomiGatewayDiscovery(
         hass.add_job, gateways, interface)
 
     _LOGGER.debug("Expecting %s gateways", len(gateways))

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -35,10 +35,10 @@ def generate_entity_id(entity_id_format: str, name: Optional[str],
                 current_ids, hass
             ).result()
 
-    name = (name or DEVICE_DEFAULT_NAME).lower()
+    name = (slugify(name) or slugify(DEVICE_DEFAULT_NAME)).lower()
 
     return ensure_unique_string(
-        entity_id_format.format(slugify(name)), current_ids)
+        entity_id_format.format(name), current_ids)
 
 
 @callback

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.3.7
-yarl==0.17.0
+yarl==0.18.0
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -5,7 +5,7 @@ import os
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['keyring==10.3.2', 'keyrings.alt==2.3']
+REQUIREMENTS = ['keyring==10.6.0', 'keyrings.alt==2.3']
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -622,7 +622,7 @@ pyCEC==0.4.13
 pyHS100==0.3.0
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.20.1
+pyRFXtrx==0.21.1
 
 # homeassistant.components.sensor.tibber
 pyTibber==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,7 +7,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.3.7
-yarl==0.17.0
+yarl==0.18.0
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -419,7 +419,7 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.5
 
 # homeassistant.scripts.keyring
-keyring==10.3.2
+keyring==10.6.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1225,7 +1225,7 @@ yeelight==0.3.3
 yeelightsunflower==0.0.8
 
 # homeassistant.components.media_extractor
-youtube_dl==2017.12.28
+youtube_dl==2017.12.31
 
 # homeassistant.components.light.zengge
 zengge==0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -177,7 +177,7 @@ colorlog==3.0.1
 
 # homeassistant.components.alarm_control_panel.concord232
 # homeassistant.components.binary_sensor.concord232
-concord232==0.14
+concord232==0.15
 
 # homeassistant.scripts.credstash
 # credstash==1.14.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ PyMVGLive==1.1.4
 PyMata==2.14
 
 # homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.6.0
+PyXiaomiGateway==0.7.0
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -349,7 +349,7 @@ hipnotify==1.0.8
 holidays==0.8.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180110.0
+home-assistant-frontend==20180112.0
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -723,7 +723,7 @@ pyhik==0.1.4
 pyhiveapi==0.2.10
 
 # homeassistant.components.homematic
-pyhomematic==0.1.36
+pyhomematic==0.1.37
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -75,7 +75,7 @@ hbmqtt==0.9.1
 holidays==0.8.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180110.0
+home-assistant-frontend==20180112.0
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ REQUIRES = [
     'voluptuous==0.10.5',
     'typing>=3,<4',
     'aiohttp==2.3.7',   # If updated, check if yarl also needs an update!
-    'yarl==0.17.0',
+    'yarl==0.18.0',
     'async_timeout==2.0.0',
     'chardet==3.0.4',
     'astral==1.4',

--- a/tests/components/binary_sensor/test_rest.py
+++ b/tests/components/binary_sensor/test_rest.py
@@ -1,0 +1,192 @@
+"""The tests for the REST binary sensor platform."""
+import unittest
+from unittest.mock import patch, Mock
+
+import requests
+from requests.exceptions import Timeout, MissingSchema
+import requests_mock
+
+from homeassistant.setup import setup_component
+import homeassistant.components.binary_sensor as binary_sensor
+import homeassistant.components.binary_sensor.rest as rest
+from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.helpers import template
+
+from tests.common import get_test_home_assistant, assert_setup_component
+
+
+class TestRestBinarySensorSetup(unittest.TestCase):
+    """Tests for setting up the REST binary sensor platform."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_missing_config(self):
+        """Test setup with configuration missing required entries."""
+        with assert_setup_component(0):
+            assert setup_component(self.hass, binary_sensor.DOMAIN, {
+                'binary_sensor': {'platform': 'rest'}})
+
+    def test_setup_missing_schema(self):
+        """Test setup with resource missing schema."""
+        with self.assertRaises(MissingSchema):
+            rest.setup_platform(self.hass, {
+                'platform': 'rest',
+                'resource': 'localhost',
+                'method': 'GET'
+            }, None)
+
+    @patch('requests.Session.send',
+           side_effect=requests.exceptions.ConnectionError())
+    def test_setup_failed_connect(self, mock_req):
+        """Test setup when connection error occurs."""
+        self.assertFalse(rest.setup_platform(self.hass, {
+            'platform': 'rest',
+            'resource': 'http://localhost',
+        }, lambda devices, update=True: None))
+
+    @patch('requests.Session.send', side_effect=Timeout())
+    def test_setup_timeout(self, mock_req):
+        """Test setup when connection timeout occurs."""
+        self.assertFalse(rest.setup_platform(self.hass, {
+            'platform': 'rest',
+            'resource': 'http://localhost',
+        }, lambda devices, update=True: None))
+
+    @requests_mock.Mocker()
+    def test_setup_minimum(self, mock_req):
+        """Test setup with minimum configuration."""
+        mock_req.get('http://localhost', status_code=200)
+        self.assertTrue(setup_component(self.hass, 'binary_sensor', {
+            'binary_sensor': {
+                'platform': 'rest',
+                'resource': 'http://localhost'
+            }
+        }))
+        self.assertEqual(2, mock_req.call_count)
+        assert_setup_component(1, 'switch')
+
+    @requests_mock.Mocker()
+    def test_setup_get(self, mock_req):
+        """Test setup with valid configuration."""
+        mock_req.get('http://localhost', status_code=200)
+        self.assertTrue(setup_component(self.hass, 'binary_sensor', {
+            'binary_sensor': {
+                'platform': 'rest',
+                'resource': 'http://localhost',
+                'method': 'GET',
+                'value_template': '{{ value_json.key }}',
+                'name': 'foo',
+                'unit_of_measurement': 'MB',
+                'verify_ssl': 'true',
+                'authentication': 'basic',
+                'username': 'my username',
+                'password': 'my password',
+                'headers': {'Accept': 'application/json'}
+            }
+        }))
+        self.assertEqual(2, mock_req.call_count)
+        assert_setup_component(1, 'binary_sensor')
+
+    @requests_mock.Mocker()
+    def test_setup_post(self, mock_req):
+        """Test setup with valid configuration."""
+        mock_req.post('http://localhost', status_code=200)
+        self.assertTrue(setup_component(self.hass, 'binary_sensor', {
+            'binary_sensor': {
+                'platform': 'rest',
+                'resource': 'http://localhost',
+                'method': 'POST',
+                'value_template': '{{ value_json.key }}',
+                'payload': '{ "device": "toaster"}',
+                'name': 'foo',
+                'unit_of_measurement': 'MB',
+                'verify_ssl': 'true',
+                'authentication': 'basic',
+                'username': 'my username',
+                'password': 'my password',
+                'headers': {'Accept': 'application/json'}
+            }
+        }))
+        self.assertEqual(2, mock_req.call_count)
+        assert_setup_component(1, 'binary_sensor')
+
+
+class TestRestBinarySensor(unittest.TestCase):
+    """Tests for REST binary sensor platform."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.rest = Mock('RestData')
+        self.rest.update = Mock('RestData.update',
+                                side_effect=self.update_side_effect(
+                                    '{ "key": false }'))
+        self.name = 'foo'
+        self.device_class = 'light'
+        self.value_template = \
+            template.Template('{{ value_json.key }}', self.hass)
+
+        self.binary_sensor = rest.RestBinarySensor(
+            self.hass, self.rest, self.name, self.device_class,
+            self.value_template)
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def update_side_effect(self, data):
+        """Side effect function for mocking RestData.update()."""
+        self.rest.data = data
+
+    def test_name(self):
+        """Test the name."""
+        self.assertEqual(self.name, self.binary_sensor.name)
+
+    def test_device_class(self):
+        """Test the device class."""
+        self.assertEqual(self.device_class, self.binary_sensor.device_class)
+
+    def test_initial_state(self):
+        """Test the initial state."""
+        self.binary_sensor.update()
+        self.assertEqual(STATE_OFF, self.binary_sensor.state)
+
+    def test_update_when_value_is_none(self):
+        """Test state gets updated to unknown when sensor returns no data."""
+        self.rest.update = Mock(
+            'RestData.update',
+            side_effect=self.update_side_effect(None))
+        self.binary_sensor.update()
+        self.assertFalse(self.binary_sensor.available)
+
+    def test_update_when_value_changed(self):
+        """Test state gets updated when sensor returns a new status."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(
+                                    '{ "key": true }'))
+        self.binary_sensor.update()
+        self.assertEqual(STATE_ON, self.binary_sensor.state)
+        self.assertTrue(self.binary_sensor.available)
+
+    def test_update_when_failed_request(self):
+        """Test state gets updated when sensor returns a new status."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(None))
+        self.binary_sensor.update()
+        self.assertFalse(self.binary_sensor.available)
+
+    def test_update_with_no_template(self):
+        """Test update when there is no value template."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect('true'))
+        self.binary_sensor = rest.RestBinarySensor(
+            self.hass, self.rest, self.name, self.device_class, None)
+        self.binary_sensor.update()
+        self.assertEqual(STATE_ON, self.binary_sensor.state)
+        self.assertTrue(self.binary_sensor.available)

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -95,7 +95,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -107,7 +107,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -116,7 +116,7 @@ DEMO_DEVICES = [{
         'name': 'Garage Door'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id': 'cover.kitchen_window',
@@ -124,7 +124,7 @@ DEMO_DEVICES = [{
         'name': 'Kitchen Window'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id': 'group.all_covers',
@@ -143,7 +143,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -155,7 +155,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -164,7 +164,7 @@ DEMO_DEVICES = [{
         'name': 'Lounge room'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id':
@@ -175,7 +175,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {

--- a/tests/components/notify/test_pushbullet.py
+++ b/tests/components/notify/test_pushbullet.py
@@ -1,0 +1,42 @@
+"""The tests for the pushbullet notification platform."""
+
+import unittest
+
+from homeassistant.setup import setup_component
+import homeassistant.components.notify as notify
+from tests.common import assert_setup_component, get_test_home_assistant
+
+
+class TestPushbullet(unittest.TestCase):
+    """Test the pushbullet notifications."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_setup(self):
+        """Test setup."""
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, 'notify', {
+                'notify': {
+                    'name': 'test',
+                    'platform': 'pushbullet',
+                    'api_key': 'MYFAKEKEY', }
+            })
+        assert handle_config[notify.DOMAIN]
+
+    def test_bad_config(self):
+        """Test set up the platform with bad/missing configuration."""
+        config = {
+            notify.DOMAIN: {
+                'name': 'test',
+                'platform': 'pushbullet',
+            }
+        }
+        with assert_setup_component(0) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert not handle_config[notify.DOMAIN]

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components import updater
 import homeassistant.util.dt as dt_util
-from tests.common import async_fire_time_changed, mock_coro
+from tests.common import async_fire_time_changed, mock_coro, mock_component
 
 NEW_VERSION = '10000.0'
 MOCK_VERSION = '10.0'
@@ -174,3 +174,24 @@ def test_error_fetching_new_version_invalid_response(hass, aioclient_mock):
                Mock(return_value=mock_coro({'fake': 'bla'}))):
         res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res is None
+
+
+@asyncio.coroutine
+def test_new_version_shows_entity_after_hour_hassio(
+        hass, mock_get_uuid, mock_get_newest_version):
+    """Test if new entity is created if new version is available / hass.io."""
+    mock_get_uuid.return_value = MOCK_HUUID
+    mock_get_newest_version.return_value = mock_coro((NEW_VERSION, ''))
+    mock_component(hass, 'hassio')
+    hass.data['hassio_hass_version'] = "999.0"
+
+    res = yield from async_setup_component(
+        hass, updater.DOMAIN, {updater.DOMAIN: {}})
+    assert res, 'Updater failed to setup'
+
+    with patch('homeassistant.components.updater.current_version',
+               MOCK_VERSION):
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+        yield from hass.async_block_till_done()
+
+    assert hass.states.is_state(updater.ENTITY_ID, "999.0")

--- a/tests/components/weather/test_yweather.py
+++ b/tests/components/weather/test_yweather.py
@@ -1,0 +1,169 @@
+"""The tests for the Yahoo weather component."""
+import json
+
+import unittest
+from unittest.mock import patch
+
+from homeassistant.components.weather import (
+    ATTR_WEATHER_HUMIDITY, ATTR_WEATHER_PRESSURE, ATTR_WEATHER_TEMPERATURE,
+    ATTR_WEATHER_WIND_BEARING, ATTR_WEATHER_WIND_SPEED)
+from homeassistant.util.unit_system import METRIC_SYSTEM
+from homeassistant.setup import setup_component
+
+from tests.common import (get_test_home_assistant, load_fixture,
+                          MockDependency)
+
+
+def _yql_queryMock(yql):  # pylint: disable=invalid-name
+    """Mock yahoo query language query."""
+    return ('{"query": {"count": 1, "created": "2017-11-17T13:40:47Z", '
+            '"lang": "en-US", "results": {"place": {"woeid": "23511632"}}}}')
+
+
+def get_woeidMock(lat, lon):  # pylint: disable=invalid-name
+    """Mock get woeid Where On Earth Identifiers."""
+    return '23511632'
+
+
+class YahooWeatherMock():
+    """Mock class for the YahooWeather object."""
+
+    def __init__(self, woeid, temp_unit):
+        """Initialize Telnet object."""
+        self.woeid = woeid
+        self.temp_unit = temp_unit
+        self._data = json.loads(load_fixture('yahooweather.json'))
+
+    # pylint: disable=no-self-use
+    def updateWeather(self):  # pylint: disable=invalid-name
+        """Return sample values."""
+        return True
+
+    @property
+    def RawData(self):  # pylint: disable=invalid-name
+        """Raw Data."""
+        if self.woeid == '12345':
+            return json.loads('[]')
+        return self._data
+
+    @property
+    def Now(self):  # pylint: disable=invalid-name
+        """Current weather data."""
+        if self.woeid == '111':
+            raise ValueError
+        return self._data['query']['results']['channel']['item']['condition']
+
+    @property
+    def Atmosphere(self):  # pylint: disable=invalid-name
+        """Atmosphere weather data."""
+        return self._data['query']['results']['channel']['atmosphere']
+
+    @property
+    def Wind(self):  # pylint: disable=invalid-name
+        """Wind weather data."""
+        return self._data['query']['results']['channel']['wind']
+
+    @property
+    def Forecast(self):  # pylint: disable=invalid-name
+        """Forecast data 0-5 Days."""
+        if self.woeid == '123123':
+            raise ValueError
+        return self._data['query']['results']['channel']['item']['forecast']
+
+
+class TestWeather(unittest.TestCase):
+    """Test the Yahoo weather component."""
+
+    DEVICES = []
+
+    def add_devices(self, devices):
+        """Mock add devices."""
+        for device in devices:
+            device.update()
+            self.DEVICES.append(device)
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.units = METRIC_SYSTEM
+
+    def tearDown(self):
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    @MockDependency('yahooweather')
+    @patch('yahooweather._yql_query', new=_yql_queryMock)
+    @patch('yahooweather.get_woeid', new=get_woeidMock)
+    @patch('yahooweather.YahooWeather', new=YahooWeatherMock)
+    def test_setup(self, mock_yahooweather):
+        """Test for typical weather data attributes."""
+        self.assertTrue(
+            setup_component(self.hass, 'weather', {
+                'weather': {
+                    'platform': 'yweather',
+                    }
+                }))
+
+        state = self.hass.states.get('weather.yweather')
+        assert state is not None
+
+        assert state.state == 'cloudy'
+
+        data = state.attributes
+        self.assertEqual(data.get(ATTR_WEATHER_TEMPERATURE), 18.0)
+        self.assertEqual(data.get(ATTR_WEATHER_HUMIDITY), 71)
+        self.assertEqual(data.get(ATTR_WEATHER_PRESSURE), 1000.0)
+        self.assertEqual(data.get(ATTR_WEATHER_WIND_SPEED), 3.94)
+        self.assertEqual(data.get(ATTR_WEATHER_WIND_BEARING), 0)
+        self.assertEqual(state.attributes.get('friendly_name'), 'Yweather')
+
+    @MockDependency('yahooweather')
+    @patch('yahooweather._yql_query', new=_yql_queryMock)
+    @patch('yahooweather.get_woeid', new=get_woeidMock)
+    @patch('yahooweather.YahooWeather', new=YahooWeatherMock)
+    def test_setup_no_data(self, mock_yahooweather):
+        """Test for note receiving data."""
+        self.assertTrue(
+            setup_component(self.hass, 'weather', {
+                'weather': {
+                    'platform': 'yweather',
+                    'woeid': '12345',
+                    }
+                }))
+
+        state = self.hass.states.get('weather.yweather')
+        assert state is not None
+
+    @MockDependency('yahooweather')
+    @patch('yahooweather._yql_query', new=_yql_queryMock)
+    @patch('yahooweather.get_woeid', new=get_woeidMock)
+    @patch('yahooweather.YahooWeather', new=YahooWeatherMock)
+    def test_setup_bad_data(self, mock_yahooweather):
+        """Test for bad forecast data."""
+        self.assertTrue(
+            setup_component(self.hass, 'weather', {
+                'weather': {
+                    'platform': 'yweather',
+                    'woeid': '123123',
+                    }
+                }))
+
+        state = self.hass.states.get('weather.yweather')
+        assert state is None
+
+    @MockDependency('yahooweather')
+    @patch('yahooweather._yql_query', new=_yql_queryMock)
+    @patch('yahooweather.get_woeid', new=get_woeidMock)
+    @patch('yahooweather.YahooWeather', new=YahooWeatherMock)
+    def test_setup_condition_error(self, mock_yahooweather):
+        """Test for bad forecast data."""
+        self.assertTrue(
+            setup_component(self.hass, 'weather', {
+                'weather': {
+                    'platform': 'yweather',
+                    'woeid': '111',
+                    }
+                }))
+
+        state = self.hass.states.get('weather.yweather')
+        assert state is None

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -31,6 +31,14 @@ def test_generate_entity_id_given_keys():
             'test.another_entity']) == 'test.overwrite_hidden_true'
 
 
+def test_generate_entity_id_with_nonlatin_name():
+    """Test generate_entity_id given a name containing non-latin characters."""
+    fmt = 'test.{}'
+    assert entity.generate_entity_id(
+        fmt, 'ホームアシスタント', current_ids=[]
+    ) == 'test.unnamed_device'
+
+
 def test_async_update_support(hass):
     """Test async update getting called."""
     sync_update = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -531,7 +531,7 @@ class TestConfig(unittest.TestCase):
         """Check that restart propagates to stop."""
         process_mock = mock.MagicMock()
         attrs = {
-            'communicate.return_value': mock_coro(('output', 'error')),
+            'communicate.return_value': mock_coro((b'output', None)),
             'wait.return_value': mock_coro(0)}
         process_mock.configure_mock(**attrs)
         mock_create.return_value = mock_coro(process_mock)
@@ -546,7 +546,7 @@ class TestConfig(unittest.TestCase):
         process_mock = mock.MagicMock()
         attrs = {
             'communicate.return_value':
-                mock_coro(('\033[34mhello'.encode('utf-8'), 'error')),
+                mock_coro(('\033[34mhello'.encode('utf-8'), None)),
             'wait.return_value': mock_coro(1)}
         process_mock.configure_mock(**attrs)
         mock_create.return_value = mock_coro(process_mock)


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
